### PR TITLE
Add --with-mpi-include, --with-mpi-lib

### DIFF
--- a/acsm_compiler_control_args.m4
+++ b/acsm_compiler_control_args.m4
@@ -42,6 +42,57 @@ AC_ARG_WITH([mpi],
                     ])
             ])
 
+
+AC_ARG_WITH([mpi],
+            AS_HELP_STRING([--with-mpi@<:@=DIR@:>@],
+                           [Prefix where MPI is installed (default is MPIHOME and then MPI_HOME)]),
+            [
+              dnl We have no way of knowing whether the user explicitly enabled mpi
+              dnl with --enable-mpi or whether it was set by default, so if the user
+              dnl specified --with-mpi=no or --without-mpi we're just going to tell them they've given
+              dnl competing options
+              AS_IF([test "$enablempi" = yes && test "$withval" = no],
+                    [AC_MSG_ERROR([Did you mean to disable MPI? If you really mean it, use the --disable-mpi option instead])]
+                    )
+              MPI="$withval"
+            ],
+            [
+              AS_ECHO(["note: MPI library path not given..."])
+              AS_IF([test x"$MPIHOME" != x],
+                    [
+                      AS_ECHO(["trying prefix=$MPIHOME"])
+                      MPI=$MPIHOME
+                    ],
+                    [
+                      AS_IF([test x"$MPI_HOME" != x],
+                            [
+                              AS_ECHO(["trying prefix=$MPI_HOME"])
+                              MPI=$MPI_HOME
+                            ])
+                    ])
+            ])
+
+AC_ARG_WITH([mpi-include],
+            AS_HELP_STRING([--with-mpi-include@<:@=DIR@:>@],
+                           [Prefix where MPI headers are installed (default is --with-mpi+/include)]),
+            [
+              MPI_INCLUDES_PATH="$withval"
+            ],
+            [
+              MPI_INCLUDES_PATH="$MPI/include"
+            ])
+
+AC_ARG_WITH([mpi-lib],
+            AS_HELP_STRING([--with-mpi-lib@<:@=DIR@:>@],
+                           [Prefix where MPI binaries are installed (default is --with-mpi+/lib)]),
+            [
+              MPI_LIBS_PATH="$withval"
+            ],
+            [
+              MPI_LIBS_PATH="$MPI/lib"
+            ])
+
+#
 # --------------------------------------------------------------
 # Allow for disable-optional
 # --------------------------------------------------------------

--- a/acsm_mpi.m4
+++ b/acsm_mpi.m4
@@ -24,10 +24,11 @@ AS_IF(
                 ])
     AC_LANG_POP([C++])
   ],
-  [test -n "$MPI"],
+  [test -n "$MPI_LIBS_PATH" -a -n "$MPI_INCLUDES_PATH"],
   [
-    MPI_LIBS_PATH="$MPI/lib"
-    MPI_INCLUDES_PATH="$MPI/include"
+    AS_ECHO(["note: Checking $MPI_LIBS_PATH and $MPI_INCLUDES_PATH for MPI"])
+    dnl Default MPI_LIBS_PATH="$MPI/lib"
+    dnl Default MPI_INCLUDES_PATH="$MPI/include"
 
     MPI_LIBS_TO_TEST=""
     AS_IF([test -e $MPI_LIBS_PATH/libmpi.a], [MPI_LIBS_TO_TEST="$MPI_LIBS_PATH/libmpi.a $MPI_LIBS_TO_TEST"])
@@ -38,7 +39,7 @@ AS_IF(
     dnl look for LAM or other MPI implementation
     AS_IF([test x"$MPI_LIBS_TO_TEST" != x],
           [
-            AS_ECHO(["note: testing $MPI_LIBS_PATH/libmpi(.a/.so)"])
+            AS_ECHO(["note: testing $MPI_LIBS_PATH/libmpi(.a/.so/.dylib)"])
 
             dnl Ensure the compiler finds the library...
             tmpLIBS=$LIBS
@@ -86,6 +87,9 @@ AS_IF(
 
             AC_LANG_RESTORE
             LIBS=$tmpLIBS
+          ],
+          [
+            AS_ECHO(["note: Could not find $MPI_LIBS_PATH/libmpi(.a/.so/.dylib)"])
           ])
 
     dnl have we not found an implementation yet?


### PR DESCRIPTION
These default to whatever comes out of --with-mpi but with /include or /lib tacked on at the end, just like we were using before, but this allows the user to set those values independently in cases where they're wholly separate directories.

This was necessary for combining clang++ with OpenMPI on my Ubuntu system, where the mpicc and so on wrappers were built to use gcc, so I need to configure with this patch and ```CXX=clang++ CC=clang --enable-mpi --with-mpi-include=/usr/include/x86_64-linux-gnu/openmpi/ --with-mpi-lib=/usr/lib/x86_64-linux-gnu/```