### PR TITLE
If detection fails reset switch

### DIFF
--- a/ax_cxx_compile_stdcxx.m4
+++ b/ax_cxx_compile_stdcxx.m4
@@ -134,6 +134,7 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
   if test x$ac_success = xno; then
     HAVE_CXX$1=0
     AC_MSG_NOTICE([No compiler with C++$1 support was found])
+    switch=
   else
     HAVE_CXX$1=1
     AC_DEFINE(HAVE_CXX$1,1,


### PR DESCRIPTION
This fixes compilation for me on my Mac environment where clang doesn't recognize the `-h` or `std=c1z` flag