### PR TITLE
Autotools compatibility updates

### DIFF
--- a/acsm_enable_paranoid.m4
+++ b/acsm_enable_paranoid.m4
@@ -14,7 +14,7 @@ AC_DEFUN([ACSM_ENABLE_PARANOID],
   # (for library code only, not contrib or external code) by configuring
   # with --enable-paranoid-warnings
   AC_ARG_ENABLE(paranoid-warnings,
-                AC_HELP_STRING([--enable-paranoid-warnings],
+                AS_HELP_STRING([--enable-paranoid-warnings],
                                [Turn on paranoid compiler warnings]),
                 [AS_CASE("${enableval}",
                          [yes], [acsm_enableparanoid=yes],

--- a/acsm_enable_werror.m4
+++ b/acsm_enable_werror.m4
@@ -13,7 +13,7 @@ AC_DEFUN([ACSM_ENABLE_WERROR],
   # into errors (for library code only, not contrib or external code)
   # by configuring with --enable-werror
   AC_ARG_ENABLE(werror,
-                AC_HELP_STRING([--enable-werror],
+                AS_HELP_STRING([--enable-werror],
                                [Turn compilation warnings into errors]),
                 [AS_CASE("${enableval}",
                          [yes], [acsm_enablewerror=yes],

--- a/acsm_mpi.m4
+++ b/acsm_mpi.m4
@@ -11,8 +11,8 @@ AS_IF(
   [test x"$MPI_USING_WRAPPERS" = x1],
   [
     AC_LANG_PUSH([C++])
-    AC_TRY_LINK([@%:@include <mpi.h>],
-                [int np; MPI_Comm_size (MPI_COMM_WORLD, &np);],
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([@%:@include <mpi.h>],
+                [int np; MPI_Comm_size (MPI_COMM_WORLD, &np);])],
                 [
                   enablempi=yes
                   MPI_IMPL="mpi-wrapper-built-in"
@@ -44,7 +44,7 @@ AS_IF(
             dnl Ensure the compiler finds the library...
             tmpLIBS=$LIBS
             AC_LANG_SAVE
-            AC_LANG_CPLUSPLUS
+            AC_LANG([C++])
 
             LIBS="-L$MPI_LIBS_PATH $LIBS"
 
@@ -102,7 +102,7 @@ AS_IF(
                     dnl Ensure the compiler finds the library...
                     tmpLIBS=$LIBS
                     AC_LANG_SAVE
-                    AC_LANG_CPLUSPLUS
+                    AC_LANG([C++])
                     LIBS="-L$MPI_LIBS_PATH $LIBS"
 
                     dnl Myricomm MPICH requires the gm library to be included too
@@ -173,7 +173,7 @@ AS_IF(
                     AS_ECHO(["note: using $MPI_INCLUDES_PATH/mpi.h"])
                     tmpCPPFLAGS=$CPPFLAGS
                     AC_LANG_SAVE
-                    AC_LANG_CPLUSPLUS
+                    AC_LANG([C++])
                     CPPFLAGS="-I$MPI_INCLUDES_PATH $CPPFLAGS"
                     AC_CHECK_HEADER([mpi.h],
                                     [
@@ -191,7 +191,7 @@ AS_IF(
                     AS_ECHO(["note: using $MPI_INCLUDES_PATH/mpi.h"])
                     tmpCPPFLAGS=$CPPFLAGS
                     AC_LANG_SAVE
-                    AC_LANG_CPLUSPLUS
+                    AC_LANG([C++])
                     CPPFLAGS="-I$MPI_INCLUDES_PATH $CPPFLAGS"
                     AC_CHECK_HEADER([mpi.h],
                                     [
@@ -212,9 +212,9 @@ AS_IF(
             dnl no MPI install found, see if the compiler "natively" supports it by
             dnl attempting to link a test application without any special flags.
             AC_LANG_SAVE
-            AC_LANG_CPLUSPLUS
-            AC_TRY_LINK([@%:@include <mpi.h>],
-                        [int np; MPI_Comm_size (MPI_COMM_WORLD, &np);],
+            AC_LANG([C++])
+            AC_LINK_IFELSE([AC_LANG_PROGRAM([@%:@include <mpi.h>],
+                        [int np; MPI_Comm_size (MPI_COMM_WORLD, &np);])],
                         [
                            MPI_IMPL="CXX-built-in"
                            AC_MSG_RESULT( [$CXX Compiler Supports MPI] )
@@ -234,8 +234,8 @@ AS_IF(
     AC_LANG_PUSH([C++])
     LIBS="$PETSC_MPI_LINK_LIBS $LIBS"
     CPPFLAGS="$PETSC_MPI_INCLUDE_DIRS $CPPFLAGS"
-    AC_TRY_LINK([@%:@include <mpi.h>],
-                [int np; MPI_Comm_size (MPI_COMM_WORLD, &np);],
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([@%:@include <mpi.h>],
+                [int np; MPI_Comm_size (MPI_COMM_WORLD, &np);])],
                 [
                   enablempi=yes
                   MPI_IMPL="petsc"
@@ -255,9 +255,9 @@ AS_IF(
   dnl get any MPI info from a PETSc install. Let's check to see if CXX natively supports MPI
   [
     AC_LANG_SAVE
-    AC_LANG_CPLUSPLUS
-    AC_TRY_LINK([@%:@include <mpi.h>],
-                [int np; MPI_Comm_size (MPI_COMM_WORLD, &np);],
+    AC_LANG([C++])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([@%:@include <mpi.h>],
+                [int np; MPI_Comm_size (MPI_COMM_WORLD, &np);])],
                 [
                    MPI_IMPL="CXX-built-in"
                    AC_MSG_RESULT( [$CXX Compiler Supports MPI] )

--- a/ax_subdirs_configure.m4
+++ b/ax_subdirs_configure.m4
@@ -38,8 +38,12 @@
 #   arguments' expect their arguments to be of the form --option-name=value.
 #
 #   This macro aims to remain as close as possible to the AC_CONFIG_SUBDIRS
-#   macro. It corrects the paths for '--cache-file' and '--srcdir' and adds
-#   '--disable-option-checking' and '--silent' if necessary.
+#   macro. It corrects the paths for '--srcdir' and adds
+#   '--disable-option-checking' and '--silent' if necessary. However, it
+#   does not change the '--cache-file' argument: typically, configure
+#   scripts run with different arguments will not be able to share the same
+#   cache. If you wish to share a single cache, you should give an absolute
+#   path to '--cache-file'.
 #
 #   This macro also sets the output variable subdirs_extra to the list of
 #   directories recorded with AX_SUBDIRS_CONFIGURE. This variable can be
@@ -147,7 +151,7 @@
 #   You should have received a copy of the GNU General Public License along
 #   with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#serial 5
+#serial 6
 
 AC_DEFUN([AX_SUBDIRS_CONFIGURE],
 [
@@ -317,16 +321,9 @@ AC_DEFUN([AX_SUBDIRS_CONFIGURE],
           if test "$silent" = yes; then
             ax_sub_configure_args="--silent $ax_sub_configure_args"
           fi
-          # Make the cache file name correct relative to the subdirectory.
-          case $cache_file in
-            [[\\/]]* | ?:[[\\/]]* )
-              ax_sub_cache_file=$cache_file ;;
-            *) # Relative name.
-              ax_sub_cache_file=$ac_top_build_prefix$cache_file ;;
-          esac
 
-          AC_MSG_NOTICE([running $SHELL $ax_sub_configure $ax_sub_configure_args --cache-file=$ac_sub_cache_file])
-          eval "\$SHELL \"$ax_sub_configure\" $ax_sub_configure_args --cache-file=\"$ax_sub_cache_file\"" \
+          AC_MSG_NOTICE([running $SHELL $ax_sub_configure $ax_sub_configure_args --cache-file=$cache_file])
+          eval "\$SHELL \"$ax_sub_configure\" $ax_sub_configure_args --cache-file=\"$cache_file\"" \
               || AC_MSG_ERROR([$ax_sub_configure failed for $ax_dir])
         fi
 


### PR DESCRIPTION
This is everything we need at this level to get a clean warning-free autoreconf in libMesh with newer autotools versions; there'll be more changes to come there.