### PR TITLE
Adding variables and a macro to enable FPE safety

### DIFF
--- a/acsm_compiler_flags.m4
+++ b/acsm_compiler_flags.m4
@@ -611,6 +611,28 @@ AC_DEFUN([ACSM_SET_FPE_SAFETY_FLAGS],
 
   AS_IF([test "$acsm_enablefpesafety" = "yes"],
         [
+          AC_LANG_PUSH([C])
+          ac_fpe_safety_save_CFLAGS="$CFLAGS"
+          CFLAGS="${CFLAGS} ${ACSM_FPE_SAFETY_FLAGS}"
+          AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[])],[],
+            [
+              AC_MSG_WARN([unable to compile C with FPE safety flag ($CC $ACSM_FPE_SAFETY_FLAGS)])
+              ACSM_FPE_SAFETY_FLAGS=""
+            ])
+          CFLAGS="$ac_fpe_safety_save_CFLAGS"
+          AC_LANG_POP([C])
+
+          AC_LANG_PUSH([C++])
+          ac_fpe_safety_save_CXXFLAGS="$CXXFLAGS"
+          CXXFLAGS="${CXXFLAGS} ${ACSM_FPE_SAFETY_FLAGS}"
+          AC_COMPILE_IFELSE([AC_LANG_PROGRAM([],[])],[],
+            [
+              AC_MSG_WARN([unable to compile C++ with FPE safety flag ($CXX $ACSM_FPE_SAFETY_FLAGS)])
+              ACSM_FPE_SAFETY_FLAGS=""
+            ])
+          CXXFLAGS="$ac_fpe_safety_save_CXXFLAGS"
+          AC_LANG_POP([C++])
+
           AS_IF([test "x$ACSM_FPE_SAFETY_FLAGS" != "x"],
                 [
                   AC_MSG_RESULT(<<< Adding $ACSM_FPE_SAFETY_FLAGS for FPE safety >>>)


### PR DESCRIPTION
Some compilers treat IEEE 754 floating-point exceptions as a standard; others by default think they're ... more what you'd call "guidelines" than actual rules.  Adding a macro for projects to request the rule-following behavior unless a user specifically configures otherwise.

This (plus an upcoming MetaPhysicL PR) fixes the FPE issues I've been seeing from clang 15 and 16 there.