### PR TITLE
Scrape $CC from PETSc, not just $CXX

### DIFF
--- a/acsm_scrape_petsc_configure.m4
+++ b/acsm_scrape_petsc_configure.m4
@@ -122,6 +122,7 @@ AC_DEFUN([ACSM_SCRAPE_PETSC_CONFIGURE],
                   PETSCLINKLIBS=`make -s -C ${PETSC_DIR} SHELL=/bin/sh getlinklibs`
                   PETSCINCLUDEDIRS=`make -s -C ${PETSC_DIR} SHELL=/bin/sh getincludedirs`
                   PETSC_CXX=`make -s -C $PETSC_DIR SHELL=/bin/sh getcxxcompiler`
+                  PETSC_CC=`make -s -C $PETSC_DIR SHELL=/bin/sh getccompiler`
                   PETSC_MPI_INCLUDE_DIRS=`make -s -C $PETSC_DIR SHELL=/bin/sh getmpiincludedirs`
                   PETSC_MPI_LINK_LIBS=`make -s -C $PETSC_DIR SHELL=/bin/sh getmpilinklibs`
                   printf '%s\n' "include $PETSC_VARS_FILE" > Makefile_config_petsc
@@ -150,6 +151,8 @@ AC_DEFUN([ACSM_SCRAPE_PETSC_CONFIGURE],
                   printf '\t%s\n' "echo \$(PETSC_SNES_LIB)" >> Makefile_config_petsc
                   printf '%s\n' "getcxxcompiler:" >> Makefile_config_petsc
                   printf '\t%s\n' "echo \$(CXX)" >> Makefile_config_petsc
+                  printf '%s\n' "getccompiler:" >> Makefile_config_petsc
+                  printf '\t%s\n' "echo \$(CC)" >> Makefile_config_petsc
                   printf '%s\n' "getmpiincludedirs:" >> Makefile_config_petsc
                   printf '\t%s\n' "echo \$(MPI_INCLUDE)" >> Makefile_config_petsc
                   printf '%s\n' "getmpilinklibs:" >> Makefile_config_petsc
@@ -159,6 +162,7 @@ AC_DEFUN([ACSM_SCRAPE_PETSC_CONFIGURE],
                   PETSC_CC_INCLUDES=`make -s -f Makefile_config_petsc SHELL=/bin/sh getPETSC_CC_INCLUDES`
                   PETSC_FC_INCLUDES=`make -s -f Makefile_config_petsc SHELL=/bin/sh getPETSC_FC_INCLUDES`
                   PETSC_CXX=`make -s -f Makefile_config_petsc SHELL=/bin/sh getcxxcompiler`
+                  PETSC_CC=`make -s -f Makefile_config_petsc SHELL=/bin/sh getccompiler`
                   PETSC_MPI_INCLUDE_DIRS=`make -s -f Makefile_config_petsc SHELL=/bin/sh getmpiincludedirs`
                   PETSC_MPI_LINK_LIBS=`make -s -f Makefile_config_petsc SHELL=/bin/sh getmpilinklibs`
                   rm -f Makefile_config_petsc


### PR DESCRIPTION
This lets me get a PETSc-build mpicc for an mpi-requiring ExodusII/NetCDF configuration.