### PR TITLE
Scrape Fortran compiler settings from PETSc

### DIFF
--- a/acsm_scrape_petsc_configure.m4
+++ b/acsm_scrape_petsc_configure.m4
@@ -123,6 +123,7 @@ AC_DEFUN([ACSM_SCRAPE_PETSC_CONFIGURE],
                   PETSCINCLUDEDIRS=`make -s -C ${PETSC_DIR} SHELL=/bin/sh getincludedirs`
                   PETSC_CXX=`make -s -C $PETSC_DIR SHELL=/bin/sh getcxxcompiler`
                   PETSC_CC=`make -s -C $PETSC_DIR SHELL=/bin/sh getccompiler`
+                  PETSC_FC=`make -s -C $PETSC_DIR SHELL=/bin/sh getfortrancompiler`
                   PETSC_MPI_INCLUDE_DIRS=`make -s -C $PETSC_DIR SHELL=/bin/sh getmpiincludedirs`
                   PETSC_MPI_LINK_LIBS=`make -s -C $PETSC_DIR SHELL=/bin/sh getmpilinklibs`
                   printf '%s\n' "include $PETSC_VARS_FILE" > Makefile_config_petsc
@@ -153,6 +154,8 @@ AC_DEFUN([ACSM_SCRAPE_PETSC_CONFIGURE],
                   printf '\t%s\n' "echo \$(CXX)" >> Makefile_config_petsc
                   printf '%s\n' "getccompiler:" >> Makefile_config_petsc
                   printf '\t%s\n' "echo \$(CC)" >> Makefile_config_petsc
+                  printf '%s\n' "getfortrancompiler:" >> Makefile_config_petsc
+                  printf '\t%s\n' "echo \$(FC)" >> Makefile_config_petsc
                   printf '%s\n' "getmpiincludedirs:" >> Makefile_config_petsc
                   printf '\t%s\n' "echo \$(MPI_INCLUDE)" >> Makefile_config_petsc
                   printf '%s\n' "getmpilinklibs:" >> Makefile_config_petsc
@@ -163,6 +166,7 @@ AC_DEFUN([ACSM_SCRAPE_PETSC_CONFIGURE],
                   PETSC_FC_INCLUDES=`make -s -f Makefile_config_petsc SHELL=/bin/sh getPETSC_FC_INCLUDES`
                   PETSC_CXX=`make -s -f Makefile_config_petsc SHELL=/bin/sh getcxxcompiler`
                   PETSC_CC=`make -s -f Makefile_config_petsc SHELL=/bin/sh getccompiler`
+                  PETSC_FC=`make -s -f Makefile_config_petsc SHELL=/bin/sh getfortrancompiler`
                   PETSC_MPI_INCLUDE_DIRS=`make -s -f Makefile_config_petsc SHELL=/bin/sh getmpiincludedirs`
                   PETSC_MPI_LINK_LIBS=`make -s -f Makefile_config_petsc SHELL=/bin/sh getmpilinklibs`
                   rm -f Makefile_config_petsc


### PR DESCRIPTION
We might need this downstream in some environments; I've now found a system where MOOSE is having trouble linking due to incompletely overridden compilers.