### PR TITLE
Better icx flags and (indirectly) force -qopenmp w/ icx >= 24.x

### DIFF
--- a/acsm_compiler_flags.m4
+++ b/acsm_compiler_flags.m4
@@ -493,13 +493,23 @@ AC_DEFUN([ACSM_SET_CXX_FLAGS],
                                   [
                                     ACSM_PROFILING_FLAGS=""
                                     ACSM_CXXFLAGS_DBG="$ACSM_CXXFLAGS_DBG -O0 -g"
-                                    ACSM_CXXFLAGS_OPT="$ACSM_CXXFLAGS_OPT -O3 -w0"
+                                    ACSM_CXXFLAGS_OPT="$ACSM_CXXFLAGS_OPT -O3"
                                     ACSM_CXXFLAGS_DEVEL="$ACSM_CXXFLAGS_DEVEL -O2 -g"
                                     ACSM_CFLAGS_DBG="$ACSM_CFLAGS_DBG -O0 -g"
-                                    ACSM_CFLAGS_OPT="$ACSM_CFLAGS_OPT -O3 -w0"
+                                    ACSM_CFLAGS_OPT="$ACSM_CFLAGS_OPT -O3"
                                     ACSM_CFLAGS_DEVEL="$ACSM_CFLAGS_DEVEL -O2 -g"
                                   ],
                                   [AC_MSG_RESULT(Unknown Intel compiler "$ACSM_GXX_VERSION")])
+                          dnl icx >= 24.x accepts -fopenmp but prefers -qopenmp, issuing a warning
+                          dnl with the former. The following causes compilation to fail with
+                          dnl -fopenmp at configuration time, thereby forcing -qopenmp.
+                          AS_CASE("$ACSM_GXX_VERSION",
+                                  [intel_icx_v21.x | intel_icx_v22.x | intel_icx_v23.x],
+                                  [],
+                                  [
+                                    CXXFLAGS="$CXXFLAGS -Werror=recommended-option"
+                                    CFLAGS="$CFLAGS -Werror=recommended-option"
+                                  ])
                        ],
 
             [nvidia], [


### PR DESCRIPTION
Tested with ic(p)x 2022.1.0, 2024.2.1 and 2025.0.0.
The two most recent, 2024.2.1 and 2025.0.0, now compile libMesh cleanly.
The oldest, 2022.1.0, produces a warning regarding fast fp math which is well documented over the web, e.g. https://github.com/assimp/assimp/issues/4450 or https://stackoverflow.com/questions/73534181/fast-floating-point-model-broken-on-next-generation-intel-compiler. I chose neither to silence the warning (so the user knows the compiler is broken), nor to switch to precise math (so the user doesn't lose performance) - the (now informed) user can then choose to silence the warning themselves, switch to a different compiler, or simply live with the consequences...

Cheers,
-N