### PR TITLE
Better C++ standard flag detection

### DIFF
--- a/acsm_cxx_compiler_standard.m4
+++ b/acsm_cxx_compiler_standard.m4
@@ -6,16 +6,13 @@
 #
 #   Check for baseline language coverage in the compiler for a
 #   version of the C++ standard in between the specified MIN_VERSION
-#   (which defaults to 2011) and MAX_VERSION (which defaults to 2017).
+#   (which defaults to 2011) and MAX_VERSION (which defaults to 2026).
 #
 #   These defaults may be updated by --cxx-std-min, --cxx-std-max, or
 #   --cxx-std (to set both) options to configure.
 #
 #   Setting a MAX_VERSION below a compiler default standard does not
 #   currently override that standard.
-#
-#   Currently this macro is capable of searching for C++11, C++14,
-#   and/or C++17 support.
 #
 #   The third argument, if specified, indicates whether you insist on
 #   extended modes (e.g. -std=gnu++14) or strict conformance modes
@@ -33,7 +30,7 @@
 #
 # LICENSE
 #
-#   Copyright (c) 2021 Roy Stogner <Roy.Stogner@inl.gov>
+#   Copyright (c) 2021-2026 Roy Stogner <Roy.Stogner@inl.gov>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
@@ -47,7 +44,7 @@ AC_DEFUN([ACSM_CXX_COMPILER_STANDARD], [dnl
 acsm_CXX_STD_MIN="$1"
 m4_if([$1], [], [acsm_CXX_STD_MIN=2011])
 acsm_CXX_STD_MAX="$2"
-m4_if([$2], [], [acsm_CXX_STD_MAX=2017])
+m4_if([$2], [], [acsm_CXX_STD_MAX=2023])
 
 m4_if([$3], [], [],
       [$3], [ext], [],
@@ -75,8 +72,8 @@ AC_ARG_WITH([cxx-std-min],
               AS_IF([test "$withval" -ge 2011],
                     [acsm_CXX_STD_MIN="$withval"],
                     [AC_MSG_ERROR(${withval} for --with-cxx-std-min must be an integer >= 2011)])
-              AS_IF([test "$withval" -gt 2017],
-                    [AC_MSG_ERROR(${withval} for --with-cxx-std-min must be an integer <= 2017)])
+              AS_IF([test "$withval" -gt 2023],
+                    [AC_MSG_ERROR(${withval} for --with-cxx-std-min must be an integer <= 2023)])
             ])
 
 # --------------------------------------------------------------
@@ -104,62 +101,28 @@ acsm_backup_CXXCPP="$CXXCPP"
 
 dnl We test for every standard in our range, so that later standards
 dnl still "count" as earlier standards too.
-  AS_IF([test 2017 -le "$acsm_CXX_STD_MAX"],
+m4_foreach_w([cxx_year], [23 20 17 14 11], [
+  CXX_YEAR=cxx_year
+  AS_IF([test "20$CXX_YEAR" -le "$acsm_CXX_STD_MAX" -a $acsm_found_cxx -eq 0],
     [
-    AS_IF([test 2017 -gt "$acsm_CXX_STD_MIN"],
-          [AX_CXX_COMPILE_STDCXX([17],[$3],[optional])],
-          [AX_CXX_COMPILE_STDCXX([17],[$3],[mandatory])])
-    AS_IF([test "$HAVE_CXX17" = "1" -a $acsm_found_cxx -eq 0],
+    AS_IF([test "20$CXX_YEAR" -gt "$acsm_CXX_STD_MIN"],
+          [AX_CXX_COMPILE_STDCXX(cxx_year,[$3],[optional])],
+          [AX_CXX_COMPILE_STDCXX(cxx_year,[$3],[mandatory])])
+    eval "HAVE_TESTED_CXX=\${HAVE_CXX$CXX_YEAR}"
+    AS_IF([test "$HAVE_TESTED_CXX" = "1" -a $acsm_found_cxx -eq 0],
            [ACSM_TEST_CXX_ALL])
-    AS_IF([test "$HAVE_CXX17" = "1" -a "x$have_cxx_all" = xyes],
+    AS_IF([test "$HAVE_TESTED_CXX" = "1" -a "x$have_cxx_all" = xyes],
           [
-           AC_MSG_NOTICE([Found C++17 standard support])
+           AC_MSG_NOTICE([Found C++$CXX_YEAR standard support])
            AS_IF([test $acsm_found_cxx -eq 0],
-                 [acsm_cxx_version=17])
+                 [acsm_cxx_version=$CXX_YEAR])
            acsm_found_cxx=1],
           [CXX="$acsm_backup_CXX"
            CXXCPP="$acsm_backup_CXXCPP"
            AS_IF([test "$HAVE_CXX17" = "0"],
-            [AC_MSG_NOTICE([Did not find C++17 standard support])])])
+            [AC_MSG_NOTICE([Did not find C++$CXX_YEAR standard support])])])
     ])
-
-  AS_IF([test 2014 -le "$acsm_CXX_STD_MAX"],
-    [
-    AS_IF([test 2014 -gt "$acsm_CXX_STD_MIN"],
-          [AX_CXX_COMPILE_STDCXX([14],[$3],[optional])],
-          [AX_CXX_COMPILE_STDCXX([14],[$3],[mandatory])])
-    AS_IF([test "$HAVE_CXX14" = "1" -a $acsm_found_cxx -eq 0],
-           [ACSM_TEST_CXX_ALL])
-    AS_IF([test "$HAVE_CXX14" = "1" -a "x$have_cxx_all" = xyes],
-          [
-           AC_MSG_NOTICE([Found C++14 standard support])
-           AS_IF([test $acsm_found_cxx -eq 0],
-                 [acsm_cxx_version=14])
-           acsm_found_cxx=1],
-          [CXX="$acsm_backup_CXX"
-           CXXCPP="$acsm_backup_CXXCPP"
-           AS_IF([test "$HAVE_CXX14" = "0"],
-            [AC_MSG_NOTICE([Did not find C++14 standard support])])])
-    ])
-
-  AS_IF([test 2011 -le "$acsm_CXX_STD_MAX"],
-    [
-    AS_IF([test 2011 -gt "$acsm_CXX_STD_MIN"],
-          [AX_CXX_COMPILE_STDCXX([11],[$3],[optional])],
-          [AX_CXX_COMPILE_STDCXX([11],[$3],[mandatory])])
-    AS_IF([test "$HAVE_CXX11" = "1" -a $acsm_found_cxx -eq 0],
-           [ACSM_TEST_CXX_ALL])
-    AS_IF([test "$HAVE_CXX11" = "1" -a "x$have_cxx_all" = xyes],
-          [
-           AC_MSG_NOTICE([Found C++11 standard support])
-           AS_IF([test $acsm_found_cxx -eq 0],
-                 [acsm_cxx_version=11])
-           acsm_found_cxx=1],
-          [CXX="$acsm_backup_CXX"
-           CXXCPP="$acsm_backup_CXXCPP"
-           AS_IF([test "$HAVE_CXX11" = "0"],
-            [AC_MSG_NOTICE([Did not find C++11 standard support])])])
-    ])
+])
 
 AS_IF([test "$acsm_found_cxx" = "1"],
       [AC_MSG_NOTICE([Using support for C++$acsm_cxx_version standard])],

--- a/acsm_cxx_compiler_standard.m4
+++ b/acsm_cxx_compiler_standard.m4
@@ -49,6 +49,7 @@ m4_if([$2], [], [acsm_CXX_STD_MAX=2023])
 m4_if([$3], [], [],
       [$3], [ext], [],
       [$3], [noext], [],
+      [$3], [defaultnoext], [],
       [m4_fatal([invalid third argument `$3' to ACSM_CXX_COMPILER_STANDARD])])dnl
 # --------------------------------------------------------------
 # How new a C++ standard should we ask for?

--- a/acsm_cxx_compiler_standard.m4
+++ b/acsm_cxx_compiler_standard.m4
@@ -6,7 +6,7 @@
 #
 #   Check for baseline language coverage in the compiler for a
 #   version of the C++ standard in between the specified MIN_VERSION
-#   (which defaults to 2011) and MAX_VERSION (which defaults to 2026).
+#   (which defaults to 2011) and MAX_VERSION (which defaults to 2023).
 #
 #   These defaults may be updated by --cxx-std-min, --cxx-std-max, or
 #   --cxx-std (to set both) options to configure.

--- a/ax_cxx_compile_stdcxx.m4
+++ b/ax_cxx_compile_stdcxx.m4
@@ -38,13 +38,14 @@
 #   Copyright (c) 2020 Jason Merrill <jason@redhat.com>
 #   Copyright (c) 2021, 2024 Jörn Heusipp <osmanx@problemloesungsmaschine.de>
 #   Copyright (c) 2015, 2022, 2023, 2024 Olly Betts
+#   Copyright (c) 2026 Roy Stogner <Roy.Stogner@inl.gov>
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 25
+#serial 26
 
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
@@ -67,17 +68,32 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
   AC_LANG_PUSH([C++])dnl
   ac_success=no
 
-  m4_if([$2], [], [dnl
-    AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
-		   ax_cv_cxx_compile_cxx$1,
-      [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
-        [ax_cv_cxx_compile_cxx$1=yes],
-        [ax_cv_cxx_compile_cxx$1=no])])
-    if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
-      ac_success=yes
-    fi])
+  m4_if([$2], [], [], [_AX_CXX_COMPILE_STDCXX_default_loop($1)])
 
-  m4_if([$2], [noext], [], [dnl
+  m4_if([$2], [noext], [], [_AX_CXX_COMPILE_STDCXX_ext_loop($1)])
+
+  m4_if([$2], [ext], [], [_AX_CXX_COMPILE_STDCXX_noext_loop($1)])
+
+  AC_LANG_POP([C++])
+  if test x$ax_cxx_compile_cxx$1_required = xtrue; then
+    if test x$ac_success = xno; then
+      AC_MSG_ERROR([*** A compiler with support for C++$1 language features is required.])
+    fi
+  fi
+  if test x$ac_success = xno; then
+    HAVE_CXX$1=0
+    AC_MSG_NOTICE([No compiler with C++$1 support was found])
+  else
+    HAVE_CXX$1=1
+    AC_DEFINE(HAVE_CXX$1,1,
+              [define if the compiler supports basic C++$1 syntax])
+  fi
+  AC_SUBST(HAVE_CXX$1)
+])
+
+
+dnl  Loop over possible GNU++ extension switches
+m4_define([_AX_CXX_COMPILE_STDCXX_ext_loop], [dnl
   if test x$ac_success = xno; then
     for alternative in ${ax_cxx_compile_alternatives}; do
       switch="-std=gnu++${alternative}"
@@ -101,7 +117,20 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
     done
   fi])
 
-  m4_if([$2], [ext], [], [dnl
+m4_define([_AX_CXX_COMPILE_STDCXX_default_loop], [dnl
+  if test x$ac_success = xno; then
+    AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
+                   ax_cv_cxx_compile_cxx$1,
+      [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+        [ax_cv_cxx_compile_cxx$1=yes],
+        [ax_cv_cxx_compile_cxx$1=no])])
+    if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
+      ac_success=yes
+    fi
+  fi])
+
+
+m4_define([_AX_CXX_COMPILE_STDCXX_noext_loop], [dnl
   if test x$ac_success = xno; then
     dnl HP's aCC needs +std=c++11 according to:
     dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
@@ -140,22 +169,7 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
       fi
     done
   fi])
-  AC_LANG_POP([C++])
-  if test x$ax_cxx_compile_cxx$1_required = xtrue; then
-    if test x$ac_success = xno; then
-      AC_MSG_ERROR([*** A compiler with support for C++$1 language features is required.])
-    fi
-  fi
-  if test x$ac_success = xno; then
-    HAVE_CXX$1=0
-    AC_MSG_NOTICE([No compiler with C++$1 support was found])
-  else
-    HAVE_CXX$1=1
-    AC_DEFINE(HAVE_CXX$1,1,
-              [define if the compiler supports basic C++$1 syntax])
-  fi
-  AC_SUBST(HAVE_CXX$1)
-])
+
 
 
 dnl  Test body for checking C++11 support

--- a/ax_cxx_compile_stdcxx.m4
+++ b/ax_cxx_compile_stdcxx.m4
@@ -4,7 +4,7 @@
 #
 # SYNOPSIS
 #
-#   AX_CXX_COMPILE_STDCXX(VERSION, [ext|noext], [mandatory|optional])
+#   AX_CXX_COMPILE_STDCXX(VERSION, [ext|noext|defaultnoext], [mandatory|optional])
 #
 # DESCRIPTION
 #
@@ -14,9 +14,12 @@
 #   '23' for the respective C++ standard version.
 #
 #   The second argument, if specified, indicates whether you insist on an
-#   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
-#   -std=c++11).  If neither is specified, you get whatever works, with
-#   preference for no added switch, and then for an extended mode.
+#   extended mode (e.g. -std=gnu++11), or a no-extensions strict
+#   conformance mode (e.g.  -std=c++11).  If neither is specified, you
+#   get whatever works, with preference for no added switch, and then
+#   for an extended mode.  If "defaultnoext" is specified, you get no
+#   added switch if that works, or you get a no-extensions switch if
+#   needed.
 #
 #   The third argument, if specified 'mandatory' or if left unspecified,
 #   indicates that baseline support for the specified C++ standard is
@@ -60,6 +63,7 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
   m4_if([$2], [], [],
         [$2], [ext], [],
         [$2], [noext], [],
+        [$2], [defaultnoext], [],
         [m4_fatal([invalid second argument `$2' to AX_CXX_COMPILE_STDCXX])])dnl
   m4_if([$3], [], [ax_cxx_compile_cxx$1_required=true],
         [$3], [mandatory], [ax_cxx_compile_cxx$1_required=true],
@@ -68,11 +72,21 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
   AC_LANG_PUSH([C++])dnl
   ac_success=no
 
-  m4_if([$2], [], [], [_AX_CXX_COMPILE_STDCXX_default_loop($1)])
+  dnl  Default "" argument or "defaultnoext" argument means we first
+  dnl  see if the compiler works as-is
+  m4_if([$2], [], [_AX_CXX_COMPILE_STDCXX_default_loop($1)])
+  m4_if([$2], [defaultnoext], [_AX_CXX_COMPILE_STDCXX_default_loop($1)])
 
-  m4_if([$2], [noext], [], [_AX_CXX_COMPILE_STDCXX_ext_loop($1)])
+  dnl  Default "" argument or "ext" argument means we try extended
+  dnl  switches
+  m4_if([$2], [], [_AX_CXX_COMPILE_STDCXX_ext_loop($1)])
+  m4_if([$2], [ext], [_AX_CXX_COMPILE_STDCXX_ext_loop($1)])
 
-  m4_if([$2], [ext], [], [_AX_CXX_COMPILE_STDCXX_noext_loop($1)])
+  dnl  Default "" argument or "noext" or "defaultnoext" argument means
+  dnl  we try non-extended switches
+  m4_if([$2], [], [_AX_CXX_COMPILE_STDCXX_noext_loop($1)])
+  m4_if([$2], [noext], [_AX_CXX_COMPILE_STDCXX_noext_loop($1)])
+  m4_if([$2], [defaultnoext], [_AX_CXX_COMPILE_STDCXX_noext_loop($1)])
 
   AC_LANG_POP([C++])
   if test x$ax_cxx_compile_cxx$1_required = xtrue; then

--- a/ax_cxx_compile_stdcxx.m4
+++ b/ax_cxx_compile_stdcxx.m4
@@ -10,13 +10,13 @@
 #
 #   Check for baseline language coverage in the compiler for the specified
 #   version of the C++ standard.  If necessary, add switches to CXX and
-#   CXXCPP to enable support.  VERSION may be '11' (for the C++11 standard)
-#   or '14' (for the C++14 standard).
+#   CXXCPP to enable support.  VERSION may be '11', '14', '17', '20', or
+#   '23' for the respective C++ standard version.
 #
 #   The second argument, if specified, indicates whether you insist on an
 #   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
 #   -std=c++11).  If neither is specified, you get whatever works, with
-#   preference for an extended mode.
+#   preference for no added switch, and then for an extended mode.
 #
 #   The third argument, if specified 'mandatory' or if left unspecified,
 #   indicates that baseline support for the specified C++ standard is
@@ -35,14 +35,16 @@
 #   Copyright (c) 2015 Moritz Klammler <moritz@klammler.eu>
 #   Copyright (c) 2016, 2018 Krzesimir Nowak <qdlacz@gmail.com>
 #   Copyright (c) 2019 Enji Cooper <yaneurabeya@gmail.com>
-#   Copyright (c) 2021 Roy Stogner <Roy.Stogner@inl.gov>
+#   Copyright (c) 2020 Jason Merrill <jason@redhat.com>
+#   Copyright (c) 2021, 2024 Jörn Heusipp <osmanx@problemloesungsmaschine.de>
+#   Copyright (c) 2015, 2022, 2023, 2024 Olly Betts
 #
 #   Copying and distribution of this file, with or without modification, are
 #   permitted in any medium without royalty provided the copyright notice
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 12
+#serial 25
 
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
@@ -51,6 +53,8 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
   m4_if([$1], [11], [ax_cxx_compile_alternatives="11 0x"],
         [$1], [14], [ax_cxx_compile_alternatives="14 1y"],
         [$1], [17], [ax_cxx_compile_alternatives="17 1z"],
+        [$1], [20], [ax_cxx_compile_alternatives="20"],
+        [$1], [23], [ax_cxx_compile_alternatives="23"],
         [m4_fatal([invalid first argument `$1' to AX_CXX_COMPILE_STDCXX])])dnl
   m4_if([$2], [], [],
         [$2], [ext], [],
@@ -63,13 +67,15 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
   AC_LANG_PUSH([C++])dnl
   ac_success=no
 
-  cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1])
-  AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
-                 $cachevar,
-  [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
-    [eval $cachevar=yes],
-    [eval $cachevar=no])])
-  AS_IF([eval test x\$$cachevar = xyes], [ac_success=yes])
+  m4_if([$2], [], [dnl
+    AC_CACHE_CHECK(whether $CXX supports C++$1 features by default,
+		   ax_cv_cxx_compile_cxx$1,
+      [AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
+        [ax_cv_cxx_compile_cxx$1=yes],
+        [ax_cv_cxx_compile_cxx$1=no])])
+    if test x$ax_cv_cxx_compile_cxx$1 = xyes; then
+      ac_success=yes
+    fi])
 
   m4_if([$2], [noext], [], [dnl
   if test x$ac_success = xno; then
@@ -100,9 +106,18 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
     dnl HP's aCC needs +std=c++11 according to:
     dnl http://h21007.www2.hp.com/portal/download/files/unprot/aCxx/PDF_Release_Notes/769149-001.pdf
     dnl Cray's crayCC needs "-h std=c++11"
+    dnl MSVC needs -std:c++NN for C++17 and later (default is C++14)
     for alternative in ${ax_cxx_compile_alternatives}; do
-      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}"; do
-        cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+      for switch in -std=c++${alternative} +std=c++${alternative} "-h std=c++${alternative}" MSVC; do
+        if test x"$switch" = xMSVC; then
+          dnl AS_TR_SH maps both `:` and `=` to `_` so -std:c++17 would collide
+          dnl with -std=c++17.  We suffix the cache variable name with _MSVC to
+          dnl avoid this.
+          switch=-std:c++${alternative}
+          cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_${switch}_MSVC])
+        else
+          cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
+        fi
         AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
                        $cachevar,
           [ac_save_CXX="$CXX"
@@ -146,22 +161,43 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
 dnl  Test body for checking C++11 support
 
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_11],
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11]
 )
-
 
 dnl  Test body for checking C++14 support
 
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_14],
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14]
 )
 
+dnl  Test body for checking C++17 support
+
 m4_define([_AX_CXX_COMPILE_STDCXX_testbody_17],
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_11
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
-  _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17]
 )
+
+dnl  Test body for checking C++20 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_20],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_20]
+)
+
+dnl  Test body for checking C++23 support
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_23],
+  [_AX_CXX_COMPILE_STDCXX_testbody_new_in_11
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_14
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_17
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_20
+   _AX_CXX_COMPILE_STDCXX_testbody_new_in_23]
+)
+
 
 dnl  Tests for new features in C++11
 
@@ -174,7 +210,21 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_11], [[
 
 #error "This is not a C++ compiler"
 
-#elif __cplusplus < 201103L
+// MSVC always sets __cplusplus to 199711L in older versions; newer versions
+// only set it correctly if /Zc:__cplusplus is specified as well as a
+// /std:c++NN switch:
+//
+// https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
+//
+// The value __cplusplus ought to have is available in _MSVC_LANG since
+// Visual Studio 2015 Update 3:
+//
+// https://learn.microsoft.com/en-us/cpp/preprocessor/predefined-macros
+//
+// This was also the first MSVC version to support C++14 so we can't use the
+// value of either __cplusplus or _MSVC_LANG to quickly rule out MSVC having
+// C++11 or C++14 support, but we can check _MSVC_LANG for C++17 and later.
+#elif __cplusplus < 201103L && !defined _MSC_VER
 
 #error "This is not a C++11 compiler"
 
@@ -465,7 +515,7 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_14], [[
 
 #error "This is not a C++ compiler"
 
-#elif __cplusplus < 201402L
+#elif __cplusplus < 201402L && !defined _MSC_VER
 
 #error "This is not a C++14 compiler"
 
@@ -589,7 +639,7 @@ m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_17], [[
 
 #error "This is not a C++ compiler"
 
-#elif __cplusplus < 201703L
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 201703L
 
 #error "This is not a C++17 compiler"
 
@@ -955,6 +1005,66 @@ namespace cxx17
 
 }  // namespace cxx17
 
-#endif  // __cplusplus < 201703L
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 201703L
+
+]])
+
+
+dnl  Tests for new features in C++20
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_20], [[
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202002L
+
+#error "This is not a C++20 compiler"
+
+#else
+
+#include <version>
+
+namespace cxx20
+{
+
+// As C++20 supports feature test macros in the standard, there is no
+// immediate need to actually test for feature availability on the
+// Autoconf side.
+
+}  // namespace cxx20
+
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202002L
+
+]])
+
+
+dnl  Tests for new features in C++23
+
+m4_define([_AX_CXX_COMPILE_STDCXX_testbody_new_in_23], [[
+
+#ifndef __cplusplus
+
+#error "This is not a C++ compiler"
+
+#elif (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202302L
+
+#error "This is not a C++23 compiler"
+
+#else
+
+#include <version>
+
+namespace cxx23
+{
+
+// As C++23 supports feature test macros in the standard, there is no
+// immediate need to actually test for feature availability on the
+// Autoconf side.
+
+}  // namespace cxx23
+
+#endif  // (defined _MSVC_LANG ? _MSVC_LANG : __cplusplus) < 202302L
 
 ]])


### PR DESCRIPTION
Mostly I want to be able to not accidentally pull in GNU extensions, but this is also a good time to bump up our flag detection to autodetect C++20 and C++23 support when requested.