### PR TITLE
C++ detection fixes

### DIFF
--- a/acsm_cxx_compiler_standard.m4
+++ b/acsm_cxx_compiler_standard.m4
@@ -104,25 +104,25 @@ dnl We test for every standard in our range, so that later standards
 dnl still "count" as earlier standards too.
 m4_foreach_w([cxx_year], [23 20 17 14 11], [
   CXX_YEAR=cxx_year
-  AS_IF([test "20$CXX_YEAR" -le "$acsm_CXX_STD_MAX" -a $acsm_found_cxx -eq 0],
-    [
-    AS_IF([test "20$CXX_YEAR" -gt "$acsm_CXX_STD_MIN"],
-          [AX_CXX_COMPILE_STDCXX(cxx_year,[$3],[optional])],
-          [AX_CXX_COMPILE_STDCXX(cxx_year,[$3],[mandatory])])
-    eval "HAVE_TESTED_CXX=\${HAVE_CXX$CXX_YEAR}"
-    AS_IF([test "$HAVE_TESTED_CXX" = "1" -a $acsm_found_cxx -eq 0],
-           [ACSM_TEST_CXX_ALL])
-    AS_IF([test "$HAVE_TESTED_CXX" = "1" -a "x$have_cxx_all" = xyes],
-          [
-           AC_MSG_NOTICE([Found C++$CXX_YEAR standard support])
-           AS_IF([test $acsm_found_cxx -eq 0],
-                 [acsm_cxx_version=$CXX_YEAR])
-           acsm_found_cxx=1],
-          [CXX="$acsm_backup_CXX"
-           CXXCPP="$acsm_backup_CXXCPP"
-           AS_IF([test "$HAVE_CXX$CXX_YEAR" = "0"],
-            [AC_MSG_NOTICE([Did not find C++$CXX_YEAR standard support])])])
-    ])
+  AS_IF([test "20$CXX_YEAR" -le "$acsm_CXX_STD_MAX"],
+        [AS_IF([test $acsm_found_cxx -eq 0],
+               [AS_IF([test "20$CXX_YEAR" -gt "$acsm_CXX_STD_MIN"],
+                      [AX_CXX_COMPILE_STDCXX(cxx_year,[$3],[optional])],
+                      [AX_CXX_COMPILE_STDCXX(cxx_year,[$3],[mandatory])])
+                eval "HAVE_TESTED_CXX=\${HAVE_CXX$CXX_YEAR}"
+                AS_IF([test "$HAVE_TESTED_CXX" = "1" -a $acsm_found_cxx -eq 0],
+                      [ACSM_TEST_CXX_ALL])
+                AS_IF([test "$HAVE_TESTED_CXX" = "1" -a "x$have_cxx_all" = xyes],
+                      [AC_MSG_NOTICE([Found C++$CXX_YEAR standard support])
+                       AS_IF([test $acsm_found_cxx -eq 0],
+                             [acsm_cxx_version=$CXX_YEAR])
+                       acsm_found_cxx=1],
+                      [CXX="$acsm_backup_CXX"
+                       CXXCPP="$acsm_backup_CXXCPP"
+                       AS_IF([test "$HAVE_CXX$CXX_YEAR" = "0"],
+                             [AC_MSG_NOTICE([Did not find C++$CXX_YEAR standard support])])])
+               ])
+        ])
 ])
 
 AS_IF([test "$acsm_found_cxx" = "1"],

--- a/acsm_cxx_compiler_standard.m4
+++ b/acsm_cxx_compiler_standard.m4
@@ -121,7 +121,12 @@ m4_foreach_w([cxx_year], [23 20 17 14 11], [
                        CXXCPP="$acsm_backup_CXXCPP"
                        AS_IF([test "$HAVE_CXX$CXX_YEAR" = "0"],
                              [AC_MSG_NOTICE([Did not find C++$CXX_YEAR standard support])])])
-               ])
+               ],
+               dnl If we support a newer C++ standard, we basically support the older ones.
+               [eval "HAVE_CXX$CXX_YEAR=1"
+                AC_SUBST(HAVE_CXXcxx_year)
+               ]
+             )
         ])
 ])
 

--- a/acsm_cxx_compiler_standard.m4
+++ b/acsm_cxx_compiler_standard.m4
@@ -120,7 +120,7 @@ m4_foreach_w([cxx_year], [23 20 17 14 11], [
            acsm_found_cxx=1],
           [CXX="$acsm_backup_CXX"
            CXXCPP="$acsm_backup_CXXCPP"
-           AS_IF([test "$HAVE_CXX17" = "0"],
+           AS_IF([test "$HAVE_CXX$CXX_YEAR" = "0"],
             [AC_MSG_NOTICE([Did not find C++$CXX_YEAR standard support])])])
     ])
 ])


### PR DESCRIPTION
This fixes some messed up console output, but more importantly it lets us know we've got support older C++ standards when we detect something with newer support.